### PR TITLE
Update Actions with Lychee and GitHub Token

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Run Ultralytics Formatting
         uses: ultralytics/actions@main
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}  # automatically generated
           python: true
           docstrings: true
           markdown: true
           spelling: true
+          links: true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,4 +22,4 @@ jobs:
           docstrings: true
           markdown: true
           spelling: true
-          links: true
+          links: false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Welcome to the MSVM (Minimum Separation Vector Mapping) project! This repository hosts the implementation of an innovative machine learning approach for geospatial information fusion and video analytics, designed to enhance situational awareness in intelligence, surveillance, and reconnaissance (ISR) applications.
 
+[![Ultralytics Actions](https://github.com/ultralytics/msvm/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/msvm/actions/workflows/format.yml)
+
 # 📑 Description
 
 The MSVM technique, introduced in our SPIE Defense + Security 2014 paper, employs advanced algorithms to map and analyze motion imagery for ISR tasks. For more details, please refer to our publication:


### PR DESCRIPTION
This pull request adds an improved Ultralytics Actions workflow to automatically format code and documentation to the new Ultralytics official standards maintained at https://github.com/ultralytics/actions.

Five individual actions are run by default now including a new broken links check for markdown and HTML files. Disable individual actions by setting them to false or removing their line, i.e. delete 'markdown: true' line to disable markdown formatting.

To customize an action use a `pyproject.toml` file in this repo. For details see https://github.com/ultralytics/actions. 

```yaml
# Ultralytics 🚀 - AGPL-3.0 license
# Ultralytics Actions https://github.com/ultralytics/actions
# This workflow automatically formats code and documentation in PRs to official Ultralytics standards

name: Ultralytics Actions

on:
  push:
    branches: [main]
  pull_request_target:
    branches: [main]

jobs:
  format:
    runs-on: ubuntu-latest
    steps:
      - name: Run Ultralytics Formatting
        uses: ultralytics/actions@main
        with:
          token: ${{ secrets.GITHUB_TOKEN }}  # automatically generated
          python: true
          docstrings: true
          markdown: true
          spelling: true
          links: true
```


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced GitHub workflow for code formatting and updated README with status badge.

### 📊 Key Changes
- Added GitHub token to workflow for authentication.
- Included new formatting checks for code, excluding link verification.
- Inserted a status badge into the README for visibility of the formatting workflow.

### 🎯 Purpose & Impact
- 🔐 The GitHub token ensures secure and authorized workflow runs.
- 🧹 Expanded formatting actions maintain code quality without checking links, preventing false positives from temporary link outages.
- 🛡️ The README badge offers immediate insight into codebase health, improving transparency and trust for users.